### PR TITLE
Nugi/update undici 7.7.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
   "overrides": {
     "ws": "8.18.1",
     "cross-spawn": "7.0.6",
-    "undici": "7.7.0",
+    "undici": "7.6.0",
     "adm-zip": "0.5.16",
     "@graphprotocol/graph-ts": "0.38.0",
     "cookie": "1.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -38,7 +38,7 @@
   "overrides": {
     "ws": "8.18.1",
     "cross-spawn": "7.0.6",
-    "undici": "7.6.0",
+    "undici": "7.7.0",
     "adm-zip": "0.5.16",
     "@graphprotocol/graph-ts": "0.38.0",
     "cookie": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "adm-zip": "0.5.16",
     "cross-spawn": "7.0.6",
     "semver": "7.7.1",
-    "undici": "7.7.0",
+    "undici": "7.6.0",
     "axios": "1.8.4",
     "cookie": "1.0.2",
     "ejs": "3.1.10"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "adm-zip": "0.5.16",
     "cross-spawn": "7.0.6",
     "semver": "7.7.1",
-    "undici": "7.6.0",
+    "undici": "7.7.0",
     "axios": "1.8.4",
     "cookie": "1.0.2",
     "ejs": "3.1.10"


### PR DESCRIPTION
change "undici" from v 7.6.0 to 7.7.0 in package.json and bun.lock

## Summary by Sourcery

Enhancements:
- Upgrade Undici dependency to the latest minor version